### PR TITLE
Add TypeScript Playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ A curated list of awesome online implementations of integrated development envir
 * [SQLFiddle](http://sqlfiddle.com/) - Run snippets of MySQL, MSSQL, PostgreSQL, SQLite, and Oracle
 * [Go Playground](https://play.golang.org/) - Run snippets for Go programming language
 * [Rust Playground](https://play.rust-lang.org/) - Run snippets of Rust programming language
+* [TypeScript Playground](https://agentcooper.github.io/typescript-play/) [<img title="Open Source" width="16" src="https://cdn.jsdelivr.net/npm/simple-icons@1.2.7/icons/github.svg" />](https://github.com/agentcooper/typescript-play) - Run snippets of TypeScript with tsconfig options and full intellisense
 
 ### Web Snippets
 


### PR DESCRIPTION
TypeScript is a typed superset of JavaScript that compiles to plain JavaScript.
Playground allows you to compile TypeScript and see JavaScript output.
Differences from typescriptlang.org/play:

– All strict options turned on by default
– More available compiler options
– Ability to switch TypeScript version
– More space for code
– More examples
– Quicker sharing, URL updates as you type
– Shorter sharing URLs
– Open source