### PR TITLE
Pin awesome-lint@0.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ git:
 language: node_js
 node_js:
   - 'node'
-script: npx awesome-lint
+script: npx awesome-lint@0.2.0


### PR DESCRIPTION
Looks like there are a lot of breaking changes so I'm going to pin the version of awesome-lint to `0.2.0` until I can determine what the new requirements are for Awesome lists.